### PR TITLE
Tên truyện trong thumbnail không click vào truyện, Chương hiện thị null nếu là chương oneshot theo tập

### DIFF
--- a/src/components/nettrom/manga-tile.tsx
+++ b/src/components/nettrom/manga-tile.tsx
@@ -35,32 +35,32 @@ const MangaTile = (props: {
                 alt={props.title}
               />
             </AspectRatio>
+            <div className="absolute bottom-0 left-0 z-[2] w-full px-2 py-1.5">
+              <h3 className="mb-2 line-clamp-2 text-[14px] font-semibold leading-tight text-white transition group-hover:line-clamp-4">
+                {props.title}
+              </h3>
+              <span className="flex items-center justify-between gap-[4px] text-[11px] text-muted-foreground">
+                <span className="flex items-center gap-[4px]">
+                  <i className="fa fa-star"></i>
+                  {Utils.Number.formatViews(
+                    Math.round(
+                      (props.mangaStatistic?.rating?.bayesian || 0) * 10,
+                    ) / 10,
+                  )}
+                </span>
+                <span className="flex items-center gap-[4px]">
+                  <i className="fa fa-comment" />
+                  {Utils.Number.formatViews(
+                    props.mangaStatistic?.comments?.repliesCount || 0,
+                  )}
+                </span>
+                <span className="flex items-center gap-[4px]">
+                  <i className="fa fa-heart" />
+                  {Utils.Number.formatViews(props.mangaStatistic?.follows || 0)}
+                </span>
+              </span>
+            </div>
           </Link>
-          <div className="absolute bottom-0 left-0 z-[2] w-full px-2 py-1.5">
-            <h3 className="mb-2 line-clamp-2 text-[14px] font-semibold leading-tight text-white transition group-hover:line-clamp-4">
-              {props.title}
-            </h3>
-            <span className="flex items-center justify-between gap-[4px] text-[11px] text-muted-foreground">
-              <span className="flex items-center gap-[4px]">
-                <i className="fa fa-star"></i>
-                {Utils.Number.formatViews(
-                  Math.round(
-                    (props.mangaStatistic?.rating?.bayesian || 0) * 10,
-                  ) / 10,
-                )}
-              </span>
-              <span className="flex items-center gap-[4px]">
-                <i className="fa fa-comment" />
-                {Utils.Number.formatViews(
-                  props.mangaStatistic?.comments?.repliesCount || 0,
-                )}
-              </span>
-              <span className="flex items-center gap-[4px]">
-                <i className="fa fa-heart" />
-                {Utils.Number.formatViews(props.mangaStatistic?.follows || 0)}
-              </span>
-            </span>
-          </div>
         </div>
         <figcaption>
           <ul className="flex flex-col gap-[4px]">

--- a/src/utils/mangadex.ts
+++ b/src/utils/mangadex.ts
@@ -58,8 +58,12 @@ export class MangaDexUtils {
           : "") +
         chapter.attributes.title
       );
-    if (chapter.attributes.volume)
-      return `Chương ${chapter.attributes.chapter} Tập ${chapter.attributes.volume}`;
+    if (chapter.attributes.volume) {
+      if (chapter.attributes.chapter) {
+        return `Chương ${chapter.attributes.chapter} Tập ${chapter.attributes.volume}`;
+      }
+      return `Oneshot Tập ${chapter.attributes.volume}`;
+    }
     if (chapter.attributes.chapter)
       return `Chương ${chapter.attributes.chapter}`;
     return "Oneshot";


### PR DESCRIPTION
### Qol: Không click được phần dưới của thumbnail để vào truyện ( tên truyện đã nằm trong thumbnail thì nên ấn được luôn) 
Solution: để phần tên truyện vào thẻ Link luôn 
Ex:
![image](https://github.com/user-attachments/assets/4f21f016-47dd-4d52-8c61-89caaef3091e)

### Bug: Nếu chương là oneshot nhưng có theo số tập sẽ hiện thị null
Solution: Hiển thị theo bên mangadex: "Oneshot Tập 1", "Oneshot Tập 2"
Ex: [Truyện oneshot](https://truyendex.com/nettrom/truyen-tranh/f790e57c-a62f-44d4-91e4-a33a04c687f8)
![image](https://github.com/user-attachments/assets/6da54071-157b-4d7e-82f7-e18296b6f327)
![image](https://github.com/user-attachments/assets/b123d2d1-a9a6-4f0e-bbc2-e68e04f36cec)
